### PR TITLE
Preserve States

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -101,6 +101,7 @@ function App() {
                                 seats: seats,
                                 total: total
                             }}
+                            user={user}
                             setters={{
                                 setTotal: setTotal,
                                 setUser: setUser,

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -39,12 +39,25 @@ function App() {
     // user info
     const [user, setUser] = useStorageState({}, 'user');
 
+    const resetStates = () => {
+        setMovieID(0);
+        setMovieName("");
+        setMovieName("");
+        setNumAdults(0);
+        setNumChildren(0);
+        setNumSeniors(0);
+        setRoomNumber(0);
+        setSeats([]);
+        setTotal(0);
+        setUser({});
+    }
+
     return (
         <>
             <Router>
                 <Switch>
                     <Route path="/" exact render={(props) => (
-                        <MovieBrowser {...props} />
+                        <MovieBrowser {...props} resetStates={resetStates} />
                     )} />
                     <Route path="/tickets/:movieID" exact render={(props) => (
                         <TicketSelection

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,30 +1,43 @@
-import React, { useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import MovieBrowser from './Components/MovieBrowser'
 import TicketSelection from './Components/TicketSelection'
 import Checkout from './Components/Checkout'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import SeatSelection from "./Components/SeatSelection";
 import OrderSummary from "./Components/OrderSummary";
-import Backdrop from "./Components/Backdrop";
 
 require('dotenv').config()
 
+// custom hook for a state that syncs with browser's local storage
+const useStorageState = (defaultValue, key) => {
+    const [value, setValue] = useState(() => {
+        const storedValue = window.localStorage.getItem(key);
+        return storedValue !== null ? JSON.parse(storedValue) : defaultValue;
+    });
+
+    useEffect(() => {
+        window.localStorage.setItem(key, JSON.stringify(value));
+    }, [key, value]);
+
+    return [value, setValue];
+}
+
 function App() {
 
-    const [movieID, setMovieID] = useState(0);
+    const [movieID, setMovieID] = useStorageState(0, 'movieID');
 
     // order detail
-    const [movieName, setMovieName] = useState("");
-    const [movieTime, setMovieTime] = useState("");
-    const [numAdults, setNumAdults] = useState(0);
-    const [numChildren, setNumChildren] = useState(0);
-    const [numSeniors, setNumSeniors] = useState(0);
-    const [roomNumber, setRoomNumber] = useState(null);
-    const [seats, setSeats] = useState([]);
-    const [total, setTotal] = useState("");
+    const [movieName, setMovieName] = useStorageState('', 'movieName');
+    const [movieTime, setMovieTime] = useStorageState('', 'movieTime');
+    const [numAdults, setNumAdults] = useStorageState(0, 'numAdults');
+    const [numChildren, setNumChildren] = useStorageState(0, 'numChildren');
+    const [numSeniors, setNumSeniors] = useStorageState(0, 'numSeniors');
+    const [roomNumber, setRoomNumber] = useStorageState(0, 'roomNumber');
+    const [seats, setSeats] = useStorageState([], 'seats');
+    const [total, setTotal] = useStorageState(0, 'total');
 
     // user info
-    const [user, setUser] = useState({});
+    const [user, setUser] = useStorageState({}, 'user');
 
     return (
         <>

--- a/client/src/Components/Checkout.js
+++ b/client/src/Components/Checkout.js
@@ -8,14 +8,14 @@ class Checkout extends React.Component {
         super(props)
 
         this.state = {
-            fname: null,
-            lname: null,
-            email: null,
-            phone: null,
-            ccnum: null,
-            ccname: null,
-            expdate: null,
-            ccv: null,
+            fname: this.props.user.fname,
+            lname: this.props.user.lname,
+            email: this.props.user.email,
+            phone: this.props.user.phone,
+            ccnum: this.props.user.ccnum,
+            ccname: this.props.user.ccname,
+            expdate: this.props.user.expdate,
+            ccv: this.props.user.ccv,
             total: null
         }
     }
@@ -59,33 +59,96 @@ class Checkout extends React.Component {
                                     <h2 className="checkout-block-title">Personal Information</h2>
 
                                     <label>First Name</label>
-                                    <input type="text" id="fname" name="firstname" placeholder="John" onChange={this.updateInfo} required />
+                                    <input
+                                        type="text"
+                                        id="fname"
+                                        name="firstname"
+                                        placeholder="John"
+                                        value={this.state.fname}
+                                        onChange={this.updateInfo}
+                                        required
+                                    />
 
                                     <label>Last Name</label>
-                                    <input type="text" id="lname" name="lastname" placeholder="Smith" onChange={this.updateInfo} required />
+                                    <input
+                                        type="text"
+                                        id="lname"
+                                        name="lastname"
+                                        placeholder="Smith"
+                                        value={this.state.lname}
+                                        onChange={this.updateInfo}
+                                        required
+                                    />
 
                                     <label>Email</label>
-                                    <input type="text" id="email" name="email" placeholder="smithj123@email.com" onChange={this.updateInfo} required />
+                                    <input
+                                        type="text"
+                                        id="email"
+                                        name="email"
+                                        placeholder="smithj123@email.com"
+                                        value={this.state.email}
+                                        onChange={this.updateInfo}
+                                        required
+                                    />
 
                                     <label>Phone Number</label>
-                                    <input type="text" id="phone" name="phonenumber" placeholder="800555555" onChange={this.updateInfo} required />
-
+                                    <input
+                                        type="text"
+                                        id="phone"
+                                        name="phonenumber"
+                                        placeholder="800555555"
+                                        value={this.state.phone}
+                                        onChange={this.updateInfo}
+                                        required
+                                    />
                                 </div>
+
                                 <div className="cc-info">
                                     <h2 className="checkout-block-title">Credit Card Information</h2>
 
                                     <label>Name on Credit Card</label>
-                                    <input type="text" id="ccname" name="cardname" placeholder="John Smith" onChange={this.updateInfo} required />
+                                    <input
+                                        type="text"
+                                        id="ccname"
+                                        name="cardname"
+                                        placeholder="John Smith"
+                                        value={this.state.ccname}
+                                        onChange={this.updateInfo}
+                                        required
+                                    />
 
                                     <label>Credit Card Number</label>
-                                    <input type="text" id="ccnum" name="cardbum" placeholder="1111-2222-3333-4444" onChange={this.updateInfo} required />
-
+                                    <input
+                                        type="text"
+                                        id="ccnum"
+                                        name="cardbum"
+                                        placeholder="1111-2222-3333-4444"
+                                        value={this.state.ccnum}
+                                        onChange={this.updateInfo}
+                                        required
+                                    />
 
                                     <label>Expiration Date</label>
-                                    <input type="text" id="expdate" name="expdate" placeholder="01/21" onChange={this.updateInfo} required />
+                                    <input
+                                        type="text"
+                                        id="expdate"
+                                        name="expdate"
+                                        placeholder="01/21"
+                                        value={this.state.expdate}
+                                        onChange={this.updateInfo}
+                                        required
+                                    />
 
                                     <label>CCV</label>
-                                    <input type="text" id="ccv" name="ccv" placeholder="123" onChange={this.updateInfo} required />
+                                    <input
+                                        type="text"
+                                        id="ccv"
+                                        name="ccv"
+                                        placeholder="123"
+                                        value={this.state.ccv}
+                                        onChange={this.updateInfo}
+                                        required
+                                    />
                                 </div>
                             </div>
                             <div className="cart">

--- a/client/src/Components/MovieBrowser.js
+++ b/client/src/Components/MovieBrowser.js
@@ -16,6 +16,10 @@ class MovieBrowser extends React.Component {
 
     // Performing API Call
     async componentDidMount() {
+        // clear local storage (previously saved data)
+        window.localStorage.clear();
+        this.props.resetStates();
+
         const movies = await MoviesDataService.fetchNowPlaying();
 
         this.setState({

--- a/client/src/Components/OrderSummary.js
+++ b/client/src/Components/OrderSummary.js
@@ -64,10 +64,11 @@ const OrderSummary = (props) => {
                         <NextButton name={'Home'} link={'/'} />
                     </>
                     :
-                    <NextButton name={'Confirm'} action={confirmOrder} />
+                    <>
+                        <NextButton name={'Confirm'} action={confirmOrder} />
+                        <BackButton />
+                    </>
             }
-
-            <BackButton />
         </>
     )
 }

--- a/client/src/Components/SeatSelection.js
+++ b/client/src/Components/SeatSelection.js
@@ -12,7 +12,7 @@ class SeatSelection extends React.Component {
         this.state = {
             loading: true,
             curSeat: [],
-            seatPos: [],
+            seatPos: this.props.order.seats,
             seatImg: []
         }
     }
@@ -80,6 +80,7 @@ class SeatSelection extends React.Component {
                     key={index}
                     isAvailable={seat.isAvailable}
                     isHandicapped={seat.isHandicapped}
+                    isSelected={this.state.seatPos.includes(seat.position)}
                     position={seat.position}
                     seatImg={seat.seatViewUrl}
                     selectFunc={this.handleSelectedSeat}

--- a/client/src/Components/SeatTile.js
+++ b/client/src/Components/SeatTile.js
@@ -19,14 +19,16 @@ class SeatTile extends React.Component {
     }
 
     setClassName() {
-        let names = "";
+        let names = "seat";
 
         if (!this.props.isAvailable) {
-            names = "seat unavailable";
-        } else if (this.props.isHandicapped) {
-            names = "seat handicapped";
-        } else {
-            names = "seat"
+            names += " unavailable";
+        } else if (this.props.isSelected) {
+            names += " selected"
+        }
+
+        if (this.props.isHandicapped) {
+            names += " handicapped";
         }
 
         return names;


### PR DESCRIPTION
Close #74 

---

**App states are preserved, unaffected by refreshing or navigating to other pages (except home)**

### Changes
- uses `window.localStorage` to store a copy of the states in `App`
- states are coercively cleared upon entering the movie browsing page
- text boxes and selections on each page are automatically filled to synchronize with the saved states
- hide back button once the order is placed to prevent duplicate orders

### Known Issue
When seat selections are pre-filled (either after refreshing or returning from another page), the seat menu (the view button) does not show up until the seat is re-selected (related to #77)